### PR TITLE
Add support for more options in config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,47 @@ The plugin runs the output of Jekyll's markdown parser [kramdown](http://kramdow
 
 ## Configuration
 
+The following fields can be set in `_config.yml`; their default values are given in the sample below.
+
+```yaml
+mathjax_csp:
+  linebreaks: false
+  single_dollars: false
+  format: AsciiMath,TeX,MathML
+  font: TeX
+  semantics: false
+  notexthints: false
+  output: SVG
+  eqno: none
+  ex_size: 6
+  width: 100
+  extensions: ""
+  font_url: "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/fonts/HTML-CSS"
+  strip_css: false
+```
 'mathjax-node-page' adds a fixed inline stylesheet to every page containing math. If you want to serve this stylesheet as an external `.css`, you can advise the plugin to strip it from the output by adding the following lines to your `_config.yml`:
 
 ```yaml
 mathjax_csp:
   strip_css: true
 ```
+
+Configuration for 'mathjax-node-page' is also available:
+
+| Key              | Description                                                  | Default                                                      |
+| ---------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `linebreaks`     | Perform automatic line-breaking                              | `false`                                                      |
+| `single_dollars` | Allow single-dollar delimiters for inline math               | `false`                                                      |
+| `format`         | Input format(s) to look for                                  | `AsciiMath,TeX,MathML`                                       |
+| `font`           | Web font to use in SVG output                                | `TeX`                                                        |
+| `semantics`      | For TeX or Asciimath source and MathML output, add input in `<semantics>` tag | `false`                                                      |
+| `notexthints`    | For TeX input and MathML output, don't add TeX-specific classes | `false`                                                      |
+| `output`         | Output format: SVG, CommonHTML, or MML                       | `SVG`                                                        |
+| `eqno`           | Equation number style (none, AMS, or all)                    | `none`                                                       |
+| `ex_size`        | Ex-size, in pixels                                           | `6`                                                          |
+| `width`          | Width of equation container in `ex`. Used for line-breaking  | `100`                                                        |
+| `extensions`     | Extra MathJax extensions (e.g. `Safe,Tex/noUndefined`)       | `""`                                                         |
+| `font_url`       | URL to use for web fonts                                     | `https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/fonts/HTML-CSS` |
 
 ## Local testing
 


### PR DESCRIPTION
This PR adds support for a few of the options supported by `mjpage`:

| `_config.yml`    | mjpage        | Description                                                  | Default                                                      |
| ---------------- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
| `linebreaks`     | `linebreaks`  | Perform automatic line-breaking                              | `false`                                                      |
| `single_dollars` | `dollars`     | Allow single-dollar delimiters for inline math                 | `false`                                                      |
| `format`         | `format`      | Input format(s) to look for                                  | `AsciiMath,TeX,MathML`                                       |
| `font`           | `font`        | Web font to use in SVG output                                | `TeX`                                                        |
| `semantics`      | `semantics`   | For TeX or Asciimath source and MathML output, add input in `<semantics>` tag | `false`                                                      |
| `notexthints`    | `notexthints` | For TeX input and MathML output, don't add TeX-specific classes | `false`                                                      |
| `output`         | `output`      | Output format: SVG, CommonHTML, or MML                       | `SVG`                                                        |
| `eqno`           | `eqno`        | Equation number style (none, AMS, or all)                    | `none`                                                       |
| `ex_size`        | `ex`          | Ex-size, in pixels                                           | `6`                                                          |
| `width`          | `width`       | Width of equation container in `ex`. Used for line-breaking  | `100`                                                        |
| `extensions`     | `extensions`  | Extra MathJax extensions (e.g. `Safe,Tex/noUndefined`)       | `""`                                                         |
| `font_url`       | `fontURL`     | URL to use for web fonts                                     | `https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/fonts/HTML-CSS` |

As you can see in the above table, I renamed some fields:

- `fontURL` to `font_url` to respect snake_case in `_config.yml`
- `ex` to `ex_size`  to give a more descriptive name

I have not added support for the following options:

| mjpage     | Description                                    | Reason                                                       |
| ---------- | ---------------------------------------------- | ------------------------------------------------------------ |
| `speech`   | Adds spoken annotations to output              | Defaults to true, so disabling it requires setting `--no-speech`, which is undocumented by mjpage (but [documented](https://github.com/yargs/yargs/blob/master/docs/tricks.md#negate) by its dependency, [yargs](https://github.com/yargs/yargs/)). I am open to implementing this, but it should be noted that it’s a special case, which complicates the code and hurts accessibility if the `speech` option is disabled. |
| `fragment` | Return body.innerHTML instead of full document | This plugin requires the full document to be returned by mjpage, so this should not be allowed. |

The way I've implemented it, the mjpage command is regenerated for every document, but I felt that this was the best way to go about it while keeping modifications of the existing code to a minimum; it would probably be better to generate it once and for all, but this probably isn't too big of a deal. I've actually never coded in Ruby before, so if you can think of a better solution, let me know 🙂 
